### PR TITLE
Offers a GUI export through HTML

### DIFF
--- a/cmd_export_messages.go
+++ b/cmd_export_messages.go
@@ -33,6 +33,7 @@ const (
 	formatJSON formatMode = iota
 	formatText
 	formatTextShort
+	formatHTML
 )
 
 type msgMode struct {
@@ -70,6 +71,8 @@ func cmdExportMessages(args []string) cmdStatus {
 				mode.format = formatText
 			case "text-short":
 				mode.format = formatTextShort
+			case "html":
+				mode.format = formatHTML
 			default:
 				log.Fatalf("invalid format: %s", arg)
 			}
@@ -211,6 +214,8 @@ func exportConversationMessages(ctx *signal.Context, d at.Dir, conv *signal.Conv
 		err = textWriteMessages(ew, msgs)
 	case formatTextShort:
 		err = textShortWriteMessages(ew, msgs)
+	case formatHTML:
+		err = textShortWriteMessages(ew, msgs)
 	}
 
 	if err != nil {
@@ -228,6 +233,8 @@ func conversationFile(d at.Dir, conv *signal.Conversation, mode msgMode) (*os.Fi
 		ext = ".json"
 	case formatText, formatTextShort:
 		ext = ".txt"
+	case formatHTML:
+		ext = ".html"
 	}
 
 	flags := os.O_WRONLY | os.O_CREATE

--- a/cmd_export_messages.go
+++ b/cmd_export_messages.go
@@ -215,7 +215,7 @@ func exportConversationMessages(ctx *signal.Context, d at.Dir, conv *signal.Conv
 	case formatTextShort:
 		err = textShortWriteMessages(ew, msgs)
 	case formatHTML:
-		err = textShortWriteMessages(ew, msgs)
+		err = htmlWriteMessages(ew, msgs)
 	}
 
 	if err != nil {

--- a/fmt_html.go
+++ b/fmt_html.go
@@ -47,11 +47,11 @@ func htmlWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
             margin-left: 33%;
             background-color: #195feeff;
         }
-	span {
-            font-size: 90%;
+		span {
+        	font-size: 90%;
             display: flex;
             justify-content: end;
-        }
+		}
     </style>
 </head>
 
@@ -108,8 +108,7 @@ func htmlWriteMessage(ew *errio.Writer, msg *signal.Message) {
 	}
 
 
-	fmt.Fprintf(ew, "<span>%s</span>", htmlFormatTime(msg.TimeSent))
-	fmt.Fprint(ew, "</section>")
+	fmt.Fprintf(ew, "<span>%s</span></section>", htmlFormatTime(msg.TimeSent))
 	fmt.Fprintln(ew)
 }
 

--- a/fmt_html.go
+++ b/fmt_html.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 Tim van der Molen <tim@kariliq.nl>
+// Copyright (c) 2024 Aloïs de Gouvello <alois@outlook.fr>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tbvdm/sigtop/errio"
+	"github.com/tbvdm/sigtop/signal"
+)
+
+func textShortWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
+  head := `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Signul</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+</head>
+
+<body>
+    <header>
+        <h1>Conversation</h1>
+    </header>
+
+    <main>
+`
+  tail := `
+    </main>
+</body>
+</html>`
+
+	fmt.Fprintf(ew, "%s", head)
+  
+	for _, msg := range msgs {
+		htmlWriteMessage(ew, &msg)
+	}
+	fmt.Fprintf(ew, "%s", tail)
+	return ew.Err()
+}
+
+func htmlWriteMessage(ew *errio.Writer, msg *signal.Message) {
+	fmt.Fprint(ew, "<div>")
+	name := "You"
+	if !msg.IsOutgoing() {
+		name = msg.Source.DisplayName()
+	}
+	fmt.Fprintf(ew, "%s %s:", textShortFormatTime(msg.TimeSent), name)
+	if msg.Type != "incoming" && msg.Type != "outgoing" {
+		fmt.Fprintf(ew, " [%s message]", msg.Type)
+	} else {
+		var details []string
+		if msg.Quote != nil {
+			details = append(details, fmt.Sprintf("reply to %s on %s", msg.Quote.Recipient.DisplayName(), textShortFormatTime(msg.Quote.ID)))
+		}
+		if len(msg.Edits) > 0 {
+			details = append(details, "edited")
+		}
+		if len(msg.Attachments) > 0 {
+			plural := ""
+			if len(msg.Attachments) > 1 {
+				plural = "s"
+			}
+			details = append(details, fmt.Sprintf("%d attachment%s", len(msg.Attachments), plural))
+		}
+		if len(details) > 0 {
+			fmt.Fprintf(ew, " [%s]", strings.Join(details, ", "))
+		}
+		if msg.Body.Text != "" {
+			fmt.Fprint(ew, " "+msg.Body.Text)
+		}
+	}
+
+	fmt.Fprint(ew, "</div>")
+	fmt.Fprintln(ew)
+}
+
+func textShortFormatTime(msec int64) string {
+	return time.UnixMilli(msec).Format("2006-01-02 15:04")
+}

--- a/fmt_html.go
+++ b/fmt_html.go
@@ -24,7 +24,7 @@ import (
 	"github.com/tbvdm/sigtop/signal"
 )
 
-func textShortWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
+func htmlWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
   head := `
 <!DOCTYPE html>
 <html lang="en">
@@ -34,6 +34,25 @@ func textShortWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Signul</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <style>
+        section {
+            margin-bottom: 1rem;
+            width: 66%;
+            background-color: #3b3b3bff;
+            padding: 0.5rem;
+            border-radius: 5px;;
+        }
+
+        .you {
+            margin-left: 33%;
+            background-color: #195feeff;
+        }
+	span {
+            font-size: 90%;
+            display: flex;
+            justify-content: end;
+        }
+    </style>
 </head>
 
 <body>
@@ -58,12 +77,11 @@ func textShortWriteMessages(ew *errio.Writer, msgs []signal.Message) error {
 }
 
 func htmlWriteMessage(ew *errio.Writer, msg *signal.Message) {
-	fmt.Fprint(ew, "<div>")
-	name := "You"
-	if !msg.IsOutgoing() {
-		name = msg.Source.DisplayName()
+	if msg.IsOutgoing() {
+		fmt.Fprint(ew, "<section class=\"you\">")
+	} else {
+		fmt.Fprintf(ew, "<section>%s:<br>", msg.Source.DisplayName())
 	}
-	fmt.Fprintf(ew, "%s %s:", textShortFormatTime(msg.TimeSent), name)
 	if msg.Type != "incoming" && msg.Type != "outgoing" {
 		fmt.Fprintf(ew, " [%s message]", msg.Type)
 	} else {
@@ -89,10 +107,12 @@ func htmlWriteMessage(ew *errio.Writer, msg *signal.Message) {
 		}
 	}
 
-	fmt.Fprint(ew, "</div>")
+
+	fmt.Fprintf(ew, "<span>%s</span>", htmlFormatTime(msg.TimeSent))
+	fmt.Fprint(ew, "</section>")
 	fmt.Fprintln(ew)
 }
 
-func textShortFormatTime(msec int64) string {
+func htmlFormatTime(msec int64) string {
 	return time.UnixMilli(msec).Format("2006-01-02 15:04")
 }

--- a/sigtop.1
+++ b/sigtop.1
@@ -216,6 +216,8 @@ This is the default.
 .It Cm text-short
 Messages are written as plain text, in short form.
 Every message is written on a single line.
+.It Cm html
+Messages are written in HTML format.
 .El
 .Pp
 By default,


### PR DESCRIPTION
How to test:

- Download the project
- Open the project
- Run `go build`
- Run `./sigtop export-messages -p passfile -f html messages`
- Open the `messages` folder
- Open any html files

Going further:

- add click to message
- use messageId as anchor
- add reactions
- add avatar
- use blockquote for quote
- make it responsive
- make it accessible
- color name
- add history
- [more]